### PR TITLE
Fix Grafana depoyment/dashboards

### DIFF
--- a/backend/01-backend.yaml
+++ b/backend/01-backend.yaml
@@ -341,7 +341,7 @@ data:
     enabled = true
     [server]
     http_port = 3000
-    root_url = http://localhost:3000/grafana
+    root_url = http://localhost:8080/grafana
     router_logging = true
     [users]
     default_theme = light

--- a/backend/01-backend.yaml
+++ b/backend/01-backend.yaml
@@ -341,7 +341,8 @@ data:
     enabled = true
     [server]
     http_port = 3000
-    root_url = http://localhost:8080/grafana
+    root_url = http://localhost:3000/grafana
+    serve_from_sub_path = true
     router_logging = true
     [users]
     default_theme = light
@@ -374,6 +375,240 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-provisioning
+  namespace: observability-backend
+---
+apiVersion: v1
+data:
+  cluster.json: |
+    {
+      "__inputs": [],
+      "__requires": [],
+      "annotations": {
+        "list": []
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "TestData",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "refresh": "",
+      "rows": [],
+      "schemaVersion": 16,
+      "style": "dark",
+      "tags": ["kubernetes"],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+        "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+      },
+      "timezone": "browser",
+      "title": "Cluster",
+      "version": 0
+    }
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  namespace: observability-backend
+---
+apiVersion: v1
+data:
+  cluster.json: |
+    {
+      "__inputs": [],
+      "__requires": [],
+      "annotations": {
+        "list": []
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "TestData",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "refresh": "",
+      "rows": [],
+      "schemaVersion": 16,
+      "style": "dark",
+      "tags": ["kubernetes"],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+        "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+      },
+      "timezone": "browser",
+      "title": "Cluster",
+      "version": 0
+    }
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards-demo
   namespace: observability-backend
 ---
 apiVersion: v1
@@ -495,6 +730,10 @@ spec:
           name: grafana-config
         - mountPath: /etc/grafana/provisioning/dashboards
           name: grafana-dashboard-provisioning
+        - mountPath: /grafana/dashboards
+          name: grafana-dashboards
+        - mountPath: /grafana/dashboards-demo
+          name: grafana-dashboards-demo
         - mountPath: /etc/grafana/provisioning/datasources
           name: grafana-datasources
         - mountPath: /etc/grafana/provisioning/notifiers
@@ -506,6 +745,12 @@ spec:
       - configMap:
           name: grafana-dashboard-provisioning
         name: grafana-dashboard-provisioning
+      - configMap:
+          name: grafana-dashboards
+        name: grafana-dashboards
+      - configMap:
+          name: grafana-dashboards-demo
+        name: grafana-dashboards-demo
       - configMap:
           name: grafana-datasources
         name: grafana-datasources

--- a/backend/01-backend.yaml
+++ b/backend/01-backend.yaml
@@ -342,7 +342,6 @@ data:
     [server]
     http_port = 3000
     root_url = http://localhost:3000/grafana
-    serve_from_sub_path = true
     router_logging = true
     [users]
     default_theme = light


### PR DESCRIPTION
fixes https://github.com/pavolloffay/kubecon-eu-2023-opentelemetry-kubernetes-tutorial/issues/7

saw this error in the logs: `level=error msg="failed to search for dashboards" error="stat /grafana/dashboards: no such file or directory"` so created some dummy `cluster.json` files for the paths specified in `dashboards.yaml`: `/grafana/dashboards` and `/grafana/dashboards-demo`