### PR TITLE
Add auto instrumentation

### DIFF
--- a/03-app-instrumentation.md
+++ b/03-app-instrumentation.md
@@ -40,9 +40,67 @@ the logs of the frontend service should contain `trace_id` and `span_id`
 Finally, look into the `index.js` file once again, there are a few additional
 `TODOs` for you!
 
+## Deploy the application
+
+Run the following command to deploy the sample application to your cluster:
+
+```bash
+kubectl -f https://github.com/pavolloffay/kubecon-eu-2023-opentelemetry-kubernetes-tutorial/blob/main/app/k8s.yaml
+```
+
+After a short while, verify that it has been deployed successfully:
+
+```bash
+$ kubectl get all -n tutorial-application
+NAME                                       READY   STATUS    RESTARTS   AGE
+pod/loadgen-deployment-5cc46c7f8c-6wwrm    1/1     Running   0          39m
+pod/backend1-deployment-69bf64db96-nhd98   1/1     Running   0          19m
+pod/frontend-deployment-bdbff495f-wc48h    1/1     Running   0          19m
+pod/backend2-deployment-856b75d696-d4m6d   1/1     Running   0          19m
+
+NAME                       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+service/backend1-service   ClusterIP   10.43.194.58   <none>        5000/TCP   39m
+service/backend2-service   ClusterIP   10.43.176.21   <none>        5165/TCP   39m
+service/frontend-service   ClusterIP   10.43.82.230   <none>        4000/TCP   39m
+
+NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/loadgen-deployment    1/1     1            1           39m
+deployment.apps/backend1-deployment   1/1     1            1           39m
+deployment.apps/frontend-deployment   1/1     1            1           39m
+deployment.apps/backend2-deployment   1/1     1            1           39m
+```
+
 ## Auto-instrumentation
 
-TODO Instrument other services with auto-instrumentation.
+The OpenTelemetry Operator supports injecting and configuring
+auto-instrumentation for you.
+
+With the operator & collector running you can now let the Operator know,
+what pods to instrument and which autoinstruemntation to use for those pods.
+This is done via the Instrumentation CRD. A basic Instrumentation resource
+looks like the following:
+
+```yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: my-instrumentation
+  namespace: tutorial-application
+spec:
+  exporter:
+    endpoint: http://otel-collector.observability-backend.svc.cluster.local:4317
+```
+
+To create a Instrumentation resource for our sample application run the following
+command
+
+```
+kubectl apply -f https://raw.githubusercontent.com/pavolloffay/kubecon-eu-2023-opentelemetry-kubernetes-tutorial/main/app/instrumentation.yaml
+```
+
+Until now we only have created the Instrumentation resource, in a next step you
+need to opt-in your services for autoinstrumentation. This is done by updating
+your service's `spec.template.metadata.annotations`
 
 ## Resource attributes
 

--- a/app/instrumentation.yaml
+++ b/app/instrumentation.yaml
@@ -2,6 +2,7 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   name: my-instrumentation
+  namespace: tutorial-application
 spec:
   exporter:
     endpoint: http://otel-collector.observability-backend.svc.cluster.local:4317

--- a/app/k8s-annotated.yaml
+++ b/app/k8s-annotated.yaml
@@ -19,6 +19,8 @@ spec:
     metadata:
       labels:
         app: backend1
+      annotations:
+        instrumentation.opentelemetry.io/inject-python: "true"
     spec:
       containers:
       - name: backend1
@@ -54,6 +56,8 @@ spec:
     metadata:
       labels:
         app: backend2
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
     spec:
       containers:
       - name: backend2
@@ -89,6 +93,8 @@ spec:
     metadata:
       labels:
         app: frontend
+      annotations:
+        instrumentation.opentelemetry.io/inject-sdk: "true"
     spec:
       containers:
       - name: frontend


### PR DESCRIPTION
This should make auto instrumentation fly (almost, see question below).

This PR fixes:
* the missing namespace in the `instrumentation.yml`
* Instructions on how to make the auto instrumentation happen
* The Node.JS service will not be auto-instrumented but properties are injected via `instrumentation.opentelemetry.io/inject-sdk: "true"`
 

I have a question where I need some help:

I don't want to deploy the application with the instrumentation annotation right ahead, because this is not really how end-users experience it. So I would like to have a flow where, the app gets deployed with out OpenTelemetry, then everything is put in place and then the application is updated with the right annotations. So far all I figured out is bringing everything down and up again.