### PR TITLE
Simplify Collector setup

### DIFF
--- a/01-collector-introduction.md
+++ b/01-collector-introduction.md
@@ -86,7 +86,7 @@ service:
 
 ### Run collector locally
 
-Here we launch a collector, which is accessible via localhost, with the previously downloaded `collector-config.yaml` description:
+Here we launch a collector, which is accessible via localhost, with the configuration shown above:
 ```bash
 docker run --rm -it --name otel-collector -p 4317:4317 -p 4318:4318 ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.74.0 --config https://raw.githubusercontent.com/pavolloffay/kubecon-eu-2023-opentelemetry-kubernetes-tutorial/main/collector-config.yaml
 ```

--- a/01-collector-introduction.md
+++ b/01-collector-introduction.md
@@ -93,7 +93,7 @@ curl -LJO https://raw.githubusercontent.com/pavolloffay/kubecon-eu-2023-opentele
 
 Here we launch a collector, which is accessible via localhost, with the previously downloaded `collector-config.yaml` description:
 ```bash
-docker run --rm -it --name otel-collector -p 4317:4317 -p 4318:4318 -v ${PWD}/collector-config.yaml:/tmp/collector-config.yaml:z ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.74.0 --config /tmp/collector-config.yaml
+docker run --rm -it --name otel-collector -p 4317:4317 -p 4318:4318 ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.74.0 --config https://raw.githubusercontent.com/pavolloffay/kubecon-eu-2023-opentelemetry-kubernetes-tutorial/main/collector-config.yaml
 ```
 
 ### Send telemetry data to your Collector

--- a/01-collector-introduction.md
+++ b/01-collector-introduction.md
@@ -84,11 +84,6 @@ service:
       exporters: [logging]
 ```
 
-Get the config to start playing:
-```bash
-curl -LJO https://raw.githubusercontent.com/pavolloffay/kubecon-eu-2023-opentelemetry-kubernetes-tutorial/main/collector-config.yaml > collector-config.yaml
-```
-
 ### Run collector locally
 
 Here we launch a collector, which is accessible via localhost, with the previously downloaded `collector-config.yaml` description:


### PR DESCRIPTION
### What does this PR do?

Similar to what is done with `kubectl`, you can directly fetch the OpenTelemetry Collector configuration from an URL in recent versions.

This PR simplifies the Docker setup for running the Collector so that you don't have to first `curl` and then mount the configuration.
